### PR TITLE
Replaced cast to ConnectionImpl, now casts to Interface. This to avoi…

### DIFF
--- a/hazelcast-jca/src/main/java/com/hazelcast/jca/ConnectionFactoryImpl.java
+++ b/hazelcast-jca/src/main/java/com/hazelcast/jca/ConnectionFactoryImpl.java
@@ -92,7 +92,7 @@ public class ConnectionFactoryImpl implements HazelcastConnectionFactory {
         if (LOGGER.isFinestEnabled()) {
             LOGGER.finest("getConnection spec: " + connSpec);
         }
-        return (HazelcastConnectionImpl) cm.allocateConnection(mcf, null);
+        return (HazelcastConnection) cm.allocateConnection(mcf, null);
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
Replaced cast to ConnectionImpl, now casts to Interface. This to avoid problems with JDK proxies on TomEE, where these cannot be cast to the implementation, only the interface. This fixes a potential class cast exception.
