### PR TITLE
Reset for non-rollbackable local transactions

### DIFF
--- a/hazelcast-jca/src/main/java/com/hazelcast/jca/HazelcastTransaction.java
+++ b/hazelcast-jca/src/main/java/com/hazelcast/jca/HazelcastTransaction.java
@@ -22,4 +22,10 @@ package com.hazelcast.jca;
  * {@link javax.resource.spi.LocalTransaction} into one interface
  */
 public interface HazelcastTransaction extends javax.resource.cci.LocalTransaction, javax.resource.spi.LocalTransaction {
+
+    /**
+     * Resets the transaction so that it can be re-used
+     * Useful when a thread finishes without calling commit or rollback
+     */
+    public void reset();
 }

--- a/hazelcast-jca/src/main/java/com/hazelcast/jca/HazelcastTransaction.java
+++ b/hazelcast-jca/src/main/java/com/hazelcast/jca/HazelcastTransaction.java
@@ -27,5 +27,5 @@ public interface HazelcastTransaction extends javax.resource.cci.LocalTransactio
      * Resets the transaction so that it can be re-used
      * Useful when a thread finishes without calling commit or rollback
      */
-    public void reset();
+    void reset();
 }

--- a/hazelcast-jca/src/main/java/com/hazelcast/jca/HazelcastTransactionImpl.java
+++ b/hazelcast-jca/src/main/java/com/hazelcast/jca/HazelcastTransactionImpl.java
@@ -41,7 +41,7 @@ public class HazelcastTransactionImpl extends JcaBase implements HazelcastTransa
     /**
      * The hazelcast transaction context itself
      */
-    private TransactionContext txContext;
+    private volatile TransactionContext txContext;
 
     HazelcastTransactionImpl(ManagedConnectionFactoryImpl factory, ManagedConnectionImpl connection) {
         this.factory = factory;


### PR DESCRIPTION
When a thread finishes without calling `commit` or `rollback` because of an error, the transaction context is leaked in the `LocalTransaction`. Calling `rollback` from another thread is not possible because Hazelcast transactions do not span multiple threads. Although resources (obtained locks) will be released automatically after timeout, this `LocalTransaction` cannot be used. We need a way to reset it so that it can be re-used. 