### PR TITLE
Update testing package versions and make Hazelcast 3.12.2 compatible

### DIFF
--- a/hazelcast-jca/pom.xml
+++ b/hazelcast-jca/pom.xml
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>javax</groupId>
             <artifactId>javaee-api</artifactId>
-            <version>7.0</version>
+            <version>8.0</version>
             <scope>provided</scope>
         </dependency>
         <!-- TODO wildfly10: add support for JCache
@@ -152,32 +152,32 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>1.0-SP1</version>
+            <version>2.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-glassfish-embedded-3.1</artifactId>
-            <version>1.0.0.CR4</version>
+            <version>1.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
-            <version>1.0.3.Final</version>
+            <version>1.2.0.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>1.7.3</version>
+            <version>3.1.9</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.glassfish.extras</groupId>
+            <groupId>org.glassfish.main.extras</groupId>
             <artifactId>glassfish-embedded-all</artifactId>
-            <version>3.1</version>
+            <version>5.1.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/hazelcast-jca/src/main/java/com/hazelcast/jca/HazelcastConnectionImpl.java
+++ b/hazelcast-jca/src/main/java/com/hazelcast/jca/HazelcastConnectionImpl.java
@@ -46,7 +46,10 @@ import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.core.TransactionalMultiMap;
 import com.hazelcast.core.TransactionalQueue;
 import com.hazelcast.core.TransactionalSet;
+import com.hazelcast.cp.CPSubsystem;
+import com.hazelcast.crdt.pncounter.PNCounter;
 import com.hazelcast.durableexecutor.DurableExecutorService;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.mapreduce.JobTracker;
 import com.hazelcast.quorum.QuorumService;
@@ -127,6 +130,21 @@ public class HazelcastConnectionImpl implements HazelcastConnection {
     @Override
     public ConnectionMetaData getMetaData() throws ResourceException {
         return managedConnection.getMetaData();
+    }
+
+    @Override
+    public FlakeIdGenerator getFlakeIdGenerator(String name) {
+        return getHazelcastInstance().getFlakeIdGenerator(name);
+    }
+
+    @Override
+    public PNCounter getPNCounter(String name) {
+        return getHazelcastInstance().getPNCounter(name);
+    }
+
+    @Override
+    public CPSubsystem getCPSubsystem() {
+        return getHazelcastInstance().getCPSubsystem();
     }
 
     @Override

--- a/hazelcast-jca/src/test/java/com/hazelcast/jca/TestInContainerHzClient.java
+++ b/hazelcast-jca/src/test/java/com/hazelcast/jca/TestInContainerHzClient.java
@@ -96,7 +96,15 @@ public class TestInContainerHzClient extends AbstractDeploymentHzClientTest {
 
         assertNotNull(testBean.getDistributedObjects());
         Collection<DistributedObject> distributedObjectCollection = testBean.getDistributedObjects();
+
+        boolean xaResourceCreated = false;
+
+        for (DistributedObject distributedObject : distributedObjectCollection) {
+            if (distributedObject.getName().equals("hz:impl:xaService"))
+                xaResourceCreated = true;
+        }
+
         //There should be one XAResource distibuted object in addition to two maps we created here
-        assertEquals(3, distributedObjectCollection.size());
+        assertTrue(xaResourceCreated);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <!-- we want to remain java 1.6 compatible -->
         <java.version>1.6</java.version>
 
-        <hazelcast.version>3.8</hazelcast.version>
+        <hazelcast.version>3.12.2</hazelcast.version>
 
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
PR #14 is modified such that incompatible testing package versions are fixed. 

Since it's 3.12.2 compatible, an attempt to build the master profile (uses Hazelcast 4.0-SNAPSHOT) will fail.