### PR TITLE
Remove legacy CountDownLatch and Semaphore.

### DIFF
--- a/hazelcast-jca/src/main/java/com/hazelcast/jca/HazelcastConnectionImpl.java
+++ b/hazelcast-jca/src/main/java/com/hazelcast/jca/HazelcastConnectionImpl.java
@@ -27,13 +27,11 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.IAtomicLong;
 import com.hazelcast.cp.IAtomicReference;
 import com.hazelcast.core.ICacheManager;
-import com.hazelcast.cp.ICountDownLatch;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.collection.IList;
 import com.hazelcast.cp.lock.ILock;
 import com.hazelcast.map.IMap;
 import com.hazelcast.collection.IQueue;
-import com.hazelcast.cp.ISemaphore;
 import com.hazelcast.collection.ISet;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
 import com.hazelcast.topic.ITopic;
@@ -59,7 +57,7 @@ import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
-import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.internal.util.ExceptionUtil;
 
 import javax.resource.NotSupportedException;
 import javax.resource.ResourceException;
@@ -204,16 +202,6 @@ public class HazelcastConnectionImpl implements HazelcastConnection {
     @Override
     public IAtomicLong getAtomicLong(String name) {
         return getHazelcastInstance().getAtomicLong(name);
-    }
-
-    @Override
-    public ICountDownLatch getCountDownLatch(String name) {
-        return getHazelcastInstance().getCountDownLatch(name);
-    }
-
-    @Override
-    public ISemaphore getSemaphore(String name) {
-        return getHazelcastInstance().getSemaphore(name);
     }
 
     @Override

--- a/hazelcast-jca/src/main/java/com/hazelcast/jca/HazelcastConnectionImpl.java
+++ b/hazelcast-jca/src/main/java/com/hazelcast/jca/HazelcastConnectionImpl.java
@@ -24,8 +24,6 @@ import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.cluster.Endpoint;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.cp.IAtomicLong;
-import com.hazelcast.cp.IAtomicReference;
 import com.hazelcast.core.ICacheManager;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.collection.IList;

--- a/hazelcast-jca/src/main/java/com/hazelcast/jca/HazelcastConnectionImpl.java
+++ b/hazelcast-jca/src/main/java/com/hazelcast/jca/HazelcastConnectionImpl.java
@@ -35,7 +35,6 @@ import com.hazelcast.collection.IQueue;
 import com.hazelcast.collection.ISet;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
 import com.hazelcast.topic.ITopic;
-import com.hazelcast.core.IdGenerator;
 import com.hazelcast.core.LifecycleService;
 import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.partition.PartitionService;
@@ -67,6 +66,7 @@ import javax.resource.cci.ResultSetInfo;
 import javax.resource.spi.ConnectionEvent;
 import javax.security.auth.Subject;
 import java.util.Collection;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
@@ -200,22 +200,17 @@ public class HazelcastConnectionImpl implements HazelcastConnection {
     }
 
     @Override
-    public IAtomicLong getAtomicLong(String name) {
-        return getHazelcastInstance().getAtomicLong(name);
-    }
-
-    @Override
     public Collection<DistributedObject> getDistributedObjects() {
         return getHazelcastInstance().getDistributedObjects();
     }
 
     @Override
-    public String addDistributedObjectListener(DistributedObjectListener distributedObjectListener) {
+    public UUID addDistributedObjectListener(DistributedObjectListener distributedObjectListener) {
         return getHazelcastInstance().addDistributedObjectListener(distributedObjectListener);
     }
 
     @Override
-    public boolean removeDistributedObjectListener(String registrationId) {
+    public boolean removeDistributedObjectListener(UUID registrationId) {
         return getHazelcastInstance().removeDistributedObjectListener(registrationId);
     }
 
@@ -291,16 +286,6 @@ public class HazelcastConnectionImpl implements HazelcastConnection {
         }
         HazelcastXAResource xaResource = getXAResource();
         return xaResource.getTransactionContext();
-    }
-
-    @Override
-    public IdGenerator getIdGenerator(String name) {
-        return getHazelcastInstance().getIdGenerator(name);
-    }
-
-    @Override
-    public <E> IAtomicReference<E> getAtomicReference(String name) {
-        return getHazelcastInstance().getAtomicReference(name);
     }
 
     @Override

--- a/hazelcast-jca/src/test/java/com/hazelcast/jca/HazelcastConnectionImplTest.java
+++ b/hazelcast-jca/src/test/java/com/hazelcast/jca/HazelcastConnectionImplTest.java
@@ -127,12 +127,6 @@ public class HazelcastConnectionImplTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void getSemaphore() {
-        ISemaphore semaphore = connection.getSemaphore("s");
-        assertSame(hz.getSemaphore("s"), semaphore);
-    }
-
-    @Test
     public void getLock() {
         ILock lock = connection.getLock("lock");
         assertSame(hz.getLock("lock"), lock);

--- a/hazelcast-jca/src/test/java/com/hazelcast/jca/HazelcastConnectionImplTest.java
+++ b/hazelcast-jca/src/test/java/com/hazelcast/jca/HazelcastConnectionImplTest.java
@@ -31,7 +31,7 @@ import com.hazelcast.collection.IQueue;
 import com.hazelcast.cp.ISemaphore;
 import com.hazelcast.splitbrainprotection.SplitBrainProtectionService;
 import com.hazelcast.topic.ITopic;
-import com.hazelcast.core.IdGenerator;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.partition.PartitionService;
 import com.hazelcast.replicatedmap.ReplicatedMap;
@@ -139,27 +139,15 @@ public class HazelcastConnectionImplTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void getAtomicLong() {
-        IAtomicLong atomicLong = connection.getAtomicLong("atomicLong");
-        assertSame(hz.getAtomicLong("atomicLong"), atomicLong);
-    }
-
-    @Test
     public void getIdGenerator() {
-        IdGenerator idGenerator = connection.getIdGenerator("id");
-        assertSame(hz.getIdGenerator("id"), idGenerator);
+        FlakeIdGenerator idGenerator = connection.getFlakeIdGenerator("id");
+        assertSame(hz.getFlakeIdGenerator("id"), idGenerator);
     }
 
     @Test
     public void getDistributedObject() {
         DistributedObject obj = connection.getDistributedObject(MapService.SERVICE_NAME, "id");
         assertSame(hz.getDistributedObject(MapService.SERVICE_NAME, "id"), obj);
-    }
-
-    @Test
-    public void getAtomicReference() {
-        IAtomicReference ref = connection.getAtomicReference("ref");
-        assertSame(hz.getAtomicReference("ref"), ref);
     }
 
     @Test

--- a/hazelcast-jca/src/test/java/com/hazelcast/jca/HazelcastTransactionImplTest.java
+++ b/hazelcast-jca/src/test/java/com/hazelcast/jca/HazelcastTransactionImplTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.internal.util.ExceptionUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;

--- a/hazelcast-jca/src/test/java/com/hazelcast/jca/ITestBean.java
+++ b/hazelcast-jca/src/test/java/com/hazelcast/jca/ITestBean.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.DistributedObjectListener;
 
 import javax.ejb.Local;
 import java.util.Collection;
+import java.util.UUID;
 
 @Local
 public interface ITestBean {
@@ -47,7 +48,7 @@ public interface ITestBean {
 
     void addDistributedObjectListener(DistributedObjectListener obj);
 
-    void removeDistributedObjectListener(String regId);
+    void removeDistributedObjectListener(UUID regId);
 
     Collection<DistributedObject> getDistributedObjects();
 }

--- a/hazelcast-jca/src/test/java/com/hazelcast/jca/TestBean.java
+++ b/hazelcast-jca/src/test/java/com/hazelcast/jca/TestBean.java
@@ -28,6 +28,7 @@ import javax.ejb.Stateful;
 import javax.resource.ResourceException;
 import javax.resource.cci.ConnectionFactory;
 import java.util.Collection;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -166,7 +167,7 @@ public class TestBean implements ITestBean {
     }
 
     @Override
-    public void removeDistributedObjectListener(String regId) {
+    public void removeDistributedObjectListener(UUID regId) {
         getConnection().removeDistributedObjectListener(regId);
     }
 

--- a/hazelcast-jca/src/test/java/com/hazelcast/jca/XATestWithJCA.java
+++ b/hazelcast-jca/src/test/java/com/hazelcast/jca/XATestWithJCA.java
@@ -28,7 +28,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.impl.xa.SerializableXID;
-import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.internal.util.ExceptionUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;


### PR DESCRIPTION
CountDownLatch and Semaphore features have been removed from HazelcastInstance interface. 
Hence the corresponding functions and tests have been pulled out as well. Also util package is moved to internal.util.