### PR TITLE
Changed min required Java version to Java 8

### DIFF
--- a/hazelcast-jca/pom.xml
+++ b/hazelcast-jca/pom.xml
@@ -137,9 +137,11 @@
         <dependency>
             <groupId>javax</groupId>
             <artifactId>javaee-api</artifactId>
-            <version>8.0</version>
+            <!-- Min required jee version is jee7 -->
+            <version>7.0</version>
             <scope>provided</scope>
         </dependency>
+
         <!-- TODO wildfly10: add support for JCache
         <dependency>
             <groupId>javax.cache</groupId>
@@ -152,32 +154,32 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>2.0</version>
+            <version>1.0-SP1</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-glassfish-embedded-3.1</artifactId>
-            <version>1.0.2</version>
+            <version>1.0.0.CR4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
-            <version>1.2.0.Final</version>
+            <version>1.0.3.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.1.9</version>
+            <version>1.7.3</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.glassfish.main.extras</groupId>
+            <groupId>org.glassfish.extras</groupId>
             <artifactId>glassfish-embedded-all</artifactId>
-            <version>5.1.0</version>
+            <version>3.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,10 @@
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- we want to remain java 1.6 compatible -->
-        <java.version>1.6</java.version>
+        <!-- Starting with Hazelcast 3.12, this module requires Java 8 -->
+        <java.version>1.8</java.version>
 
-        <hazelcast.version>3.12.2</hazelcast.version>
+        <hazelcast.version>3.12.3</hazelcast.version>
 
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
Changed min required Java version to Java 8 since Hazelcast 3.12 requires Java 8 and reverted back for Java EE 7 compatibility.